### PR TITLE
fix a typo in readme

### DIFF
--- a/readme
+++ b/readme
@@ -8,7 +8,7 @@ scene changes than Scxvid. It may also detect some that Scxvid missed.
 WWXD is considerably faster than Scxvid, possibly about six times.
 
 There is no log file. Instead, the frames are tagged with the property
-"SceneChange" (1 or 0).
+"Scenechange" (1 or 0).
 
 The license is the same as Xvid's, i.e. GPL2.
 


### PR DESCRIPTION
In fact, the frame property name should be Scenechange.